### PR TITLE
fix syntax error on "SCREEN SECTION FROM"

### DIFF
--- a/sudoku.cbl
+++ b/sudoku.cbl
@@ -629,7 +629,7 @@ SCREEN SECTION.
     05 BOTTOM-SECTION.
         10  VALUE "STEPS TO SOLUTION: "                 LINE 21 COL 10.
         10  SC-COUNTER                                  LINE 21 COL 29
-                     FROM FUNCTION TRIM(STEPS-COUNTER-D).          
+                   PIC X(10)  FROM FUNCTION TRIM(STEPS-COUNTER-D).          
         10  VALUE "N - NEXT SOLUTION"                   LINE 23 COL 30.
         10  VALUE "Q - TO QUIT"                         LINE 24 COL 30.
         10  VALUE "ENTER RESPONSE:"                     LINE 25 COL 30.


### PR DESCRIPTION
the `PIC` is mandatory to resolve the size

see https://sourceforge.net/p/gnucobol/discussion/cobol/thread/7787e97fdd for a discussion of this issue (with cobc not compiling the original source), that led GnuCOBOL to add an explicit check (as also defined by COBOL standard).

I haven't checked but instead of
`PIC X(10) FROM FUNCTION TRIM(STEPS-COUNTER-D).`
you may want to check the result of something like
`PIC z(9)9 FROM STEPS-COUNTER-D`.